### PR TITLE
Relax decoding of response data.

### DIFF
--- a/src/check_cve/check.py
+++ b/src/check_cve/check.py
@@ -61,7 +61,7 @@ def is_vulnerable(host, retries=2, timeout=10):
 
     logging.debug(f"Response status: {response.status}")
 
-    decoded_data = response.data.decode()
+    decoded_data = response.data.decode("utf-8", errors="ignore")
     logging.debug(f"Data:\n{decoded_data}")
 
     return INSECURE_CONTENT in decoded_data

--- a/tests/test_check_cve.py
+++ b/tests/test_check_cve.py
@@ -128,3 +128,16 @@ def test_non_vuln_host():
             mock_lib.PoolManager().request().status = 403
             return_code = check_cve.check.main()
             assert return_code == 0, "main() should return success"
+
+
+def test_non_utf8_response():
+    """Verify the utility handles responses containing invalid utf-8 data."""
+    # Hebrew string saying "forged"
+    bogus = "מזויף means bogus"
+    bogus_iso_8859_8 = bogus.encode("iso-8859-8")
+    with patch.object(sys, "argv", ["exe_name", "--log-level=debug", "github.com"]):
+        with patch("check_cve.check.urllib3") as mock_lib:
+            mock_lib.PoolManager().request().data = bogus_iso_8859_8
+            mock_lib.PoolManager().request().status = 403
+            return_code = check_cve.check.main()
+            assert return_code == 0, "main() should return success"


### PR DESCRIPTION

When decoding response data the tool will now ignore encoding errors. 
This fixes #5.


## 🗣 Description

Add the `ignore` flag to the byte stream `decode()`.
Add a test to demonstrate ignoring errors in a non-`utf-8` byte stream.

## 💭 Motivation and Context

Folks were running into this in issue #5.

## 🧪 Testing

Wrote a new test.
Pointed tool at sites that had encodings other than `utf-8` 

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
